### PR TITLE
fix: updated for new KDE

### DIFF
--- a/package/contents/ui/ContainerListPage.qml
+++ b/package/contents/ui/ContainerListPage.qml
@@ -194,7 +194,7 @@ ColumnLayout{
                 width: containerListView.width
             }
 
-            Kirigami.PlaceholderMessage {
+            PlasmaExtras.PlaceholderMessage {
                 anchors.centerIn: parent
                 visible: containerListView.count === 0
                 text: {
@@ -202,11 +202,6 @@ ColumnLayout{
                     else if (error !== "") return "Some error occurred.";
                     else return "Start your docker!";
                     }
-                icon.name: {
-                    if (filter.text !== "") return Qt.resolvedUrl("icons/dockio-cube.svg");
-                    else if (error !== "") return Qt.resolvedUrl("icons/dockio-error.svg");
-                    else return Qt.resolvedUrl("icons/dockio-icon.svg");
-                }
 
             }
         }


### PR DESCRIPTION
In new KDE widget show error:
```
file:///home/USERNAME/.local/share/plasma/plasmoids/org.kde.plasma.dockio/contents/ui/main.qml:155:26: Type ContainerListPage unavailable

file:///home/USERNAME/.local/share/plasma/plasmoids/org.kde.plasma.dockio/contents/ui/ContainerListPage.qml:197:13: Type Kirigami.PlaceholderMessage unavailable

qrc:/qt/qml/org/kde/kirigami/controls/PlaceholderMessage.qml:197:51: Cannot assign object of type "Primitives.IconPropertiesGroup" to property of type "IconPropertiesGroup_QMLTYPE_1284*" as the former is neither the same as the latter nor a sub-class of it.
```

this PR fixed this