### PR TITLE
Port to KDE Plasma 6 and fix container refresh delay bug

### DIFF
--- a/package/contents/Utils.js
+++ b/package/contents/Utils.js
@@ -156,7 +156,7 @@ function startContainerCallback(resCode, containerId, containerName) {
 
     if (resCode === "204") {
         notifMessage = "container started successfully.";
-        invokeDelayTimerCallback(dockerCommand.fetchContainers.get());
+        invokeDelayTimerCallback(() => dockerCommand.fetchContainers.get());
         notifBuild(containerName, notifMessage);
         if (cfg.debug) console.log(`Container ${containerName} started successfully.`);
     } else if (resCode === "304") {
@@ -180,7 +180,7 @@ function stopContainerCallback(resCode, containerId, containerName) {
     if (resCode === "204") {
         notifMessage = "container stopped successfully.";
         notifBuild(containerName, notifMessage);
-        invokeDelayTimerCallback(dockerCommand.fetchContainers.get());
+        invokeDelayTimerCallback(() => dockerCommand.fetchContainers.get());
         if (cfg.debug) console.log(`Container ${containerName} stopped successfully.`);
     } else if (resCode === "304") {
         errorMessage = `Container ${containerName} is already stopped.`;
@@ -202,7 +202,7 @@ function restartContainerCallback(resCode, containerId, containerName) {
 
     if (resCode === "204") {
         notifMessage = "container restarted successfully.";
-        invokeDelayTimerCallback(dockerCommand.fetchContainers.get());
+        invokeDelayTimerCallback(() => dockerCommand.fetchContainers.get());
         notifBuild(containerName, notifMessage);
         if (cfg.debug) console.log(`Container ${containerName} restarted successfully.`);
     } else if (resCode === "404") {
@@ -223,7 +223,7 @@ function deleteContainerCallback(resCode, containerId, containerName) {
 
     if (resCode === "204") {
         notifMessage = "container deleted successfully.";
-        invokeDelayTimerCallback(dockerCommand.fetchContainers.get());
+        invokeDelayTimerCallback(() => dockerCommand.fetchContainers.get());
         notifBuild(containerName, notifMessage);
         if (cfg.debug) console.log(`Container ${containerName} deleted successfully.`);
     } else if (resCode === "400") {

--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -1,9 +1,16 @@
 import QtQuick
+import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 import "../Utils.js" as Utils
 
 MouseArea {
     id: compact
+    
+    Layout.minimumWidth: Kirigami.Units.iconSizes.small
+    Layout.minimumHeight: Kirigami.Units.iconSizes.small
+    implicitWidth: Kirigami.Units.gridUnit
+    implicitHeight: Kirigami.Units.gridUnit
+
     property bool wasExpanded: false
     acceptedButtons: Qt.LeftButton | Qt.MiddleButton
     hoverEnabled: true

--- a/package/contents/ui/ContainerItemDelegate.qml
+++ b/package/contents/ui/ContainerItemDelegate.qml
@@ -143,7 +143,7 @@ PlasmaComponents.ItemDelegate {
                 id: debugStartToolButton
                 visible: cfg.debug
                 text: i18n("Start")
-                icon.name: Qt.resolvedUrl("icons/dockio-start.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-start.svg")
                 onClicked: Utils.commands["startContainer"].run(containerId, containerName);
 
                 PlasmaComponents.ToolTip{ text: parent.text }
@@ -154,7 +154,7 @@ PlasmaComponents.ItemDelegate {
                 id: debugStopToolButton
                 visible: cfg.debug
                 text: i18n("Stop")
-                icon.name: Qt.resolvedUrl("icons/dockio-stop.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-stop.svg")
                 onClicked: Utils.commands["stopContainer"].run(containerId, containerName);
 
                 PlasmaComponents.ToolTip{ text: parent.text }
@@ -165,7 +165,7 @@ PlasmaComponents.ItemDelegate {
                 id: actionToolButton
                 visible: !cfg.debug
                 text: ["running", "removing", "restarting", "created"].includes(containerState) ? i18n("Stop") : i18n("Start")
-                icon.name: ["running", "removing", "restarting", "created"].includes(containerState) ? Qt.resolvedUrl("icons/dockio-stop.svg") : Qt.resolvedUrl("icons/dockio-start.svg")
+                icon.source: ["running", "removing", "restarting", "created"].includes(containerState) ? Qt.resolvedUrl("icons/dockio-stop.svg") : Qt.resolvedUrl("icons/dockio-start.svg")
                 onClicked: {
                     if (["running", "removing", "restarting", "created"].includes(containerState)) {
                         Utils.commands["stopContainer"].run(containerId, containerName);
@@ -181,7 +181,7 @@ PlasmaComponents.ItemDelegate {
             PlasmaComponents.ToolButton  {
                 id: restartToolButton
                 text: i18n("Restart")
-                icon.name: Qt.resolvedUrl("icons/dockio-refresh.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-refresh.svg")
                 onClicked: Utils.commands["restartContainer"].run(containerId, containerName);
 
                 PlasmaComponents.ToolTip{ text: parent.text }
@@ -192,7 +192,7 @@ PlasmaComponents.ItemDelegate {
                 id: deleteToolButton
                 visible: !cfg.moveDeleteButton
                 text: i18n("Delete")
-                icon.name: Qt.resolvedUrl("icons/dockio-trash.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-trash.svg")
                 onClicked: containerListPage.createActionsDialog(containerId, containerName, "delete");
 
                 PlasmaComponents.ToolTip{ text: parent.text }
@@ -203,7 +203,7 @@ PlasmaComponents.ItemDelegate {
                 id: contextMenuButton
                 checkable: true
                 text: i18n("More")
-                icon.name: Qt.resolvedUrl("icons/dockio-option.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-option.svg")
 
                 onClicked: {
                     createContextMenu(containerId, containerName);

--- a/package/contents/ui/ContainerListPage.qml
+++ b/package/contents/ui/ContainerListPage.qml
@@ -4,7 +4,6 @@ import QtQuick.Controls as QQC2
 import org.kde.ksvg as KSvg
 import org.kde.kirigami as Kirigami
 import org.kde.kitemmodels as KItemModels
-import org.kde.plasma.extras as PlasmaExtras
 import org.kde.plasma.components as PlasmaComponents
 import "../Utils.js" as Utils
 
@@ -59,9 +58,41 @@ ColumnLayout{
         }
     }
 
-    property var header: PlasmaExtras.PlasmoidHeading {
 
-        contentItem: RowLayout {
+
+    model: KItemModels.KSortFilterProxyModel {
+        id: filterModel
+        sourceModel: containerModel
+        filterRoleName: "containerName"
+        filterRegularExpression: RegExp(filter.text, "i")
+        filterCaseSensitivity: Qt.CaseInsensitive
+        sortCaseSensitivity: Qt.CaseInsensitive
+        sortRoleName: sortBy
+        recursiveFilteringEnabled: true
+        sortOrder: ascending ? Qt.AscendingOrder : Qt.DescendingOrder
+    }
+
+    // Header item inside the layout
+    Item {
+        id: headerItem
+        Layout.fillWidth: true
+        implicitHeight: headerLayout.implicitHeight + Kirigami.Units.smallSpacing * 2
+        
+        Rectangle {
+            anchors.fill: parent
+            color: Kirigami.Theme.backgroundColor
+            opacity: 0.8
+        }
+        
+        RowLayout {
+            id: headerLayout
+            anchors {
+                left: parent.left
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                leftMargin: Kirigami.Units.smallSpacing
+                rightMargin: Kirigami.Units.smallSpacing
+            }
             spacing: 0
             
             enabled: containerModel.count > 0
@@ -85,7 +116,7 @@ ColumnLayout{
                 }
             }
 
-            PlasmaExtras.SearchField {
+            Kirigami.SearchField {
                 id: filter
                 Layout.fillWidth: true
                 // focus: !Kirigami.InputMethod.willShowOnActive
@@ -93,7 +124,7 @@ ColumnLayout{
             
             PlasmaComponents.ToolButton {
                 text: i18n("Refresh")
-                icon.name: Qt.resolvedUrl("icons/dockio-refresh.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-refresh.svg")
                 onClicked: {
                     dockerCommand.fetchContainers.get();
                     fetchTimer.restart();
@@ -105,23 +136,11 @@ ColumnLayout{
         }
     }
 
-    model: KItemModels.KSortFilterProxyModel {
-        id: filterModel
-        sourceModel: containerModel
-        filterRoleName: "containerName"
-        filterRegularExpression: RegExp(filter.text, "i")
-        filterCaseSensitivity: Qt.CaseInsensitive
-        sortCaseSensitivity: Qt.CaseInsensitive
-        sortRoleName: sortBy
-        recursiveFilteringEnabled: true
-        sortOrder: ascending ? Qt.AscendingOrder : Qt.DescendingOrder
-    }
-
     Kirigami.InlineMessage {
         id: errorMessage
         width: parent.width
         type: Kirigami.MessageType.Error
-        icon.name: Qt.resolvedUrl("icons/dockio-error.svg")
+        icon.source: Qt.resolvedUrl("icons/dockio-error.svg")
         text: main.error
         visible: main.error != ""
         actions: Kirigami.Action {
@@ -174,7 +193,9 @@ ColumnLayout{
             id: containerListView
 
             model: containerModel
-            highlight: PlasmaExtras.Highlight { }
+            highlight: Rectangle {
+                color: Kirigami.Theme.hoverColor
+            }
             highlightMoveDuration: 0
             highlightResizeDuration: 0
             currentIndex: -1
@@ -194,20 +215,35 @@ ColumnLayout{
                 width: containerListView.width
             }
 
-            Kirigami.PlaceholderMessage {
+            ColumnLayout {
                 anchors.centerIn: parent
+                width: parent.width - Kirigami.Units.gridUnit * 2
                 visible: containerListView.count === 0
-                text: {
-                    if (filter.text !== "") return "No results.";
-                    else if (error !== "") return "Some error occurred.";
-                    else return "Start your docker!";
+                spacing: Kirigami.Units.largeSpacing
+
+                Kirigami.Icon {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: Kirigami.Units.iconSizes.huge
+                    Layout.preferredHeight: Kirigami.Units.iconSizes.huge
+                    source: {
+                        if (filter.text !== "") return Qt.resolvedUrl("icons/dockio-cube.svg");
+                        else if (error !== "") return Qt.resolvedUrl("icons/dockio-error.svg");
+                        else return Qt.resolvedUrl("icons/dockio-icon.svg");
                     }
-                icon.name: {
-                    if (filter.text !== "") return Qt.resolvedUrl("icons/dockio-cube.svg");
-                    else if (error !== "") return Qt.resolvedUrl("icons/dockio-error.svg");
-                    else return Qt.resolvedUrl("icons/dockio-icon.svg");
                 }
 
+                PlasmaComponents.Label {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                    font.bold: true
+                    font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.2
+                    text: {
+                        if (filter.text !== "") return i18n("No results.");
+                        else if (error !== "") return i18n("Some error occurred.");
+                        else return i18n("Start your docker!");
+                    }
+                }
             }
         }
     }

--- a/package/contents/ui/ContainerOptPage.qml
+++ b/package/contents/ui/ContainerOptPage.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as QQC2
 import org.kde.kirigami as Kirigami
-import org.kde.plasma.extras as PlasmaExtras
 import org.kde.plasma.components as PlasmaComponents
 import "../Utils.js" as Utils
 
@@ -17,13 +16,28 @@ ColumnLayout {
     property string containerInfo: ""
     property alias containerInspectText: containerInspectText
 
-    property PlasmaExtras.PlasmoidHeading header: PlasmaExtras.PlasmoidHeading {
-        background.visible: false
+    // Header item inside the layout
+    Item {
+        id: headerItem
+        Layout.fillWidth: true
+        implicitHeight: statsToolbar.implicitHeight + Kirigami.Units.smallSpacing * 2
+
+        Rectangle {
+            anchors.fill: parent
+            color: Kirigami.Theme.backgroundColor
+            opacity: 0.8
+        }
 
         RowLayout {
             id: statsToolbar
             spacing: 0
-            anchors.fill: parent
+            anchors {
+                left: parent.left
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                leftMargin: Kirigami.Units.smallSpacing
+                rightMargin: Kirigami.Units.smallSpacing
+            }
 
             PlasmaComponents.Label {
                 id: containerNameLabel
@@ -36,7 +50,7 @@ ColumnLayout {
             PlasmaComponents.ToolButton {
                 id: inspectToolButton
                 text: i18n("Inspect")
-                icon.name: Qt.resolvedUrl("icons/dockio-inspect.svg")
+                icon.source: Qt.resolvedUrl("icons/dockio-inspect.svg")
                 onClicked: {
                     Utils.commands["inspectContainer"].run(containerId, containerName);
                     containerInfoText.text = "";

--- a/package/contents/ui/components/ContextMenu.qml
+++ b/package/contents/ui/components/ContextMenu.qml
@@ -20,7 +20,7 @@ PlasmaComponents.Menu {
         id: execMenu
         width: Kirigami.Units.gridUnit * 7
         title: i18n("Exec")
-        icon.name: Qt.resolvedUrl("../icons/dockio-term.svg")
+        icon.source: Qt.resolvedUrl("../icons/dockio-term.svg")
         closePolicy: QQC2.Popup.CloseOnPressOutside
 
         PlasmaComponents.MenuItem {
@@ -76,7 +76,7 @@ PlasmaComponents.Menu {
 
     PlasmaComponents.MenuItem {
         text: i18n("Logs")
-        icon.name: Qt.resolvedUrl("../icons/dockio-logs.svg")
+        icon.source: Qt.resolvedUrl("../icons/dockio-logs.svg")
         onTriggered: {
             dockerCommand.executable.exec(cfg.terminalCommand + ` $SHELL -c "docker logs -f ${containerId}"`);
         }
@@ -96,7 +96,7 @@ PlasmaComponents.Menu {
         visible: cfg.moveDeleteButton
         height: visible ? undefined : 0
         text: i18n("Delete")
-        icon.name: Qt.resolvedUrl("../icons/dockio-trash.svg")
+        icon.source: Qt.resolvedUrl("../icons/dockio-trash.svg")
         onTriggered: {
             containerListPage.createActionsDialog(containerId, containerName, "delete");
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -1,11 +1,10 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as QQC2
-import org.kde.notification
+import org.kde.notification 1.0
 import org.kde.plasma.plasmoid
 import org.kde.kirigami as Kirigami
 import org.kde.plasma.core as PlasmaCore
-import org.kde.plasma.extras as PlasmaExtras
 import "../Utils.js" as Utils
 
 PlasmoidItem {
@@ -28,7 +27,7 @@ PlasmoidItem {
 
     switchWidth: Kirigami.Units.gridUnit * 5
     switchHeight: Kirigami.Units.gridUnit * 5
-    Plasmoid.status: (containerModel.count || error !== "") ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.PassiveStatus
+    Plasmoid.status: (containerModel.count || error !== "") ? Plasmoid.ActiveStatus : Plasmoid.PassiveStatus
     toolTipMainText: i18n("Dockio")
     toolTipSubText: statusMessage
     Component.onCompleted: () => {
@@ -125,6 +124,7 @@ PlasmoidItem {
                 } else if (iconName === "dockio-stop") {
                     return Qt.resolvedUrl("icons/dockio-stop.svg")
                 }
+                return ""
             }
             onTriggered: {
                 if (command === "startDocker") {
@@ -138,16 +138,13 @@ PlasmoidItem {
 
     compactRepresentation: CompactRepresentation {}
 
-    fullRepresentation: PlasmaExtras.Representation {
+    fullRepresentation: Item {
         id: dialogItem
 
         Layout.minimumWidth: Kirigami.Units.gridUnit * 24
         Layout.minimumHeight: Kirigami.Units.gridUnit * 24
         Layout.maximumWidth: Kirigami.Units.gridUnit * 80
         Layout.maximumHeight: Kirigami.Units.gridUnit * 40
-        collapseMarginsHint: true
-
-        header: stack.currentItem.header
 
         QQC2.StackView {
             id: stack


### PR DESCRIPTION
This pull request ports the Dockio widget to KDE Plasma 6 specifications (removes obsolete PlasmaExtras components, fixes unversioned notification import crash, and maps local icon URLs to `icon.source` instead of `icon.name`). In addition, it fixes a bug in `Utils.js` where `dockerCommand.fetchContainers.get()` was evaluated immediately in `invokeDelayTimerCallback`, bypassing the 1.5-second refresh delay.